### PR TITLE
fix!: replace to bracketSameLine

### DIFF
--- a/index.json
+++ b/index.json
@@ -1,9 +1,9 @@
 {
   "$schema": "https://json.schemastore.org/prettierrc.json",
   "arrowParens": "always",
+  "bracketSameLine": false,
   "bracketSpacing": true,
   "endOfLine": "lf",
-  "jsxBracketSameLine": false,
   "jsxSingleQuote": false,
   "quoteProps": "as-needed",
   "semi": false,

--- a/package.json
+++ b/package.json
@@ -14,6 +14,9 @@
   "license": "MIT",
   "main": "index.json",
   "name": "@inabagumi/prettier-config",
+  "peerDependencies": {
+    "prettier": ">= 2.4.0"
+  },
   "prettier": "./index.json",
   "repository": {
     "type": "git",


### PR DESCRIPTION
BREAKING CHANGE: jsxBracketSameLine has been deprecated since Prettier 2.4.